### PR TITLE
refactor: remove unused `import atexit` from play/__init__.py

### DIFF
--- a/play/__init__.py
+++ b/play/__init__.py
@@ -1,6 +1,5 @@
 """The library to make pygame easier to use."""
 
-import atexit
 import pygame
 
 from .api import *


### PR DESCRIPTION
The atexit module is imported and used in play/api/utils.py, making this import in __init__.py redundant.

https://claude.ai/code/session_01Hsajngm6YPocaCFAzaA6db