### PR TITLE
feat: no more start_physics after collisions have been registered

### DIFF
--- a/play/objects/text.py
+++ b/play/objects/text.py
@@ -53,7 +53,7 @@ class Text(Sprite):
             # Render text at scaled font size for better quality
             if self._size != 100:
                 scaled_font_size = max(round(self._font_size * self._size / 100), 1)
-                scaled_font = pygame.font.Font(self._pygame_font, scaled_font_size)
+                scaled_font = pygame.font.Font(self._font_path, scaled_font_size)
                 self._image = scaled_font.render(
                     self._words, True, _color_name_to_rgb(self._color)
                 )
@@ -123,15 +123,12 @@ class Text(Sprite):
     def _load_font(self, font_name, font_size):
         """Helper method to load a font, either from a file or system."""
         if font_name == "default":
-            self._pygame_font = pygame.font.Font(
-                pygame.font.get_default_font(), font_size
-            )
+            self._font_path = pygame.font.get_default_font()
         elif os.path.isfile(font_name):
-            self._pygame_font = pygame.font.Font(font_name, font_size)
+            self._font_path = font_name
         else:
             play_logger.warning(
                 "File to font doesnt exist, Using default font", exc_info=True
             )
-            self._pygame_font = pygame.font.Font(
-                pygame.font.get_default_font(), font_size
-            )
+            self._font_path = pygame.font.get_default_font()
+        self._pygame_font = pygame.font.Font(self._font_path, font_size)

--- a/tests/objects_attributes/test_hide_show.py
+++ b/tests/objects_attributes/test_hide_show.py
@@ -323,6 +323,16 @@ def test_hide_in_when_clicked_callback():
         num_frames[0] += 1
 
         # Post a real pygame click event at frame 10
+        if num_frames[0] == 9:
+            # First move the mouse to the box's center so mouse.is_touching works
+            screen_x = int(screen.width / 2)
+            screen_y = int(screen.height / 2)
+            motion_event = pygame.event.Event(
+                pygame.MOUSEMOTION,
+                {"pos": (screen_x, screen_y), "rel": (0, 0), "buttons": (0, 0, 0)},
+            )
+            pygame.event.post(motion_event)
+
         if num_frames[0] == 10:
             # Convert play coordinates (0, 0) to pygame screen coordinates
             screen_x = int(screen.width / 2)

--- a/tests/physics/test_start_physics_callbacks.py
+++ b/tests/physics/test_start_physics_callbacks.py
@@ -1,15 +1,14 @@
-"""Test that calling start_physics again preserves callbacks without duplicating them."""
+"""Test that calling start_physics raises an error when callbacks are already registered."""
 
 import pytest
 
 
-def test_when_touching_callbacks_not_duplicated():
-    """Calling start_physics a second time should not duplicate when_touching callbacks."""
+def test_start_physics_raises_when_touching_registered():
+    """start_physics should raise RuntimeError if when_touching callbacks exist."""
     import sys
 
     sys.path.insert(0, ".")
     import play
-    from play.callback import callback_manager, CallbackType
 
     ball = play.new_circle(x=0, y=0, radius=20)
     ball.start_physics(obeys_gravity=False)
@@ -17,39 +16,24 @@ def test_when_touching_callbacks_not_duplicated():
     wall = play.new_box(x=200, y=0, width=10, height=100)
     wall.start_physics(obeys_gravity=False, can_move=False)
 
-    touch_count = [0]
-
     @ball.when_touching(wall)
     async def on_touch():
-        touch_count[0] += 1
+        pass
 
-    callbacks_before = list(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING, id(ball)) or []
-    )
-    count_before = len(callbacks_before)
-
-    # Call start_physics again
-    ball.start_physics(obeys_gravity=False)
-
-    callbacks_after = list(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING, id(ball)) or []
-    )
-    count_after = len(callbacks_after)
-
-    assert (
-        count_before == count_after
-    ), f"when_touching callbacks changed from {count_before} to {count_after} after start_physics"
+    with pytest.raises(
+        RuntimeError, match="already has collision callbacks registered"
+    ):
+        ball.start_physics(obeys_gravity=False)
 
     play.stop_program()
 
 
-def test_when_touching_wall_callbacks_not_duplicated():
-    """Calling start_physics a second time should not duplicate when_touching_wall callbacks."""
+def test_start_physics_raises_when_touching_wall_registered():
+    """start_physics should raise RuntimeError if when_touching_wall callbacks exist."""
     import sys
 
     sys.path.insert(0, ".")
     import play
-    from play.callback import callback_manager, CallbackType
 
     ball = play.new_circle(x=0, y=0, radius=20)
     ball.start_physics(obeys_gravity=False)
@@ -58,32 +42,20 @@ def test_when_touching_wall_callbacks_not_duplicated():
     async def on_wall():
         pass
 
-    callbacks_before = list(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING_WALL, id(ball)) or []
-    )
-    count_before = len(callbacks_before)
-
-    ball.start_physics(obeys_gravity=False)
-
-    callbacks_after = list(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING_WALL, id(ball)) or []
-    )
-    count_after = len(callbacks_after)
-
-    assert (
-        count_before == count_after
-    ), f"when_touching_wall callbacks changed from {count_before} to {count_after} after start_physics"
+    with pytest.raises(
+        RuntimeError, match="already has collision callbacks registered"
+    ):
+        ball.start_physics(obeys_gravity=False)
 
     play.stop_program()
 
 
-def test_when_stopped_touching_callbacks_not_duplicated():
-    """Calling start_physics a second time should not duplicate when_stopped_touching callbacks."""
+def test_start_physics_raises_when_stopped_touching_registered():
+    """start_physics should raise RuntimeError if when_stopped_touching callbacks exist."""
     import sys
 
     sys.path.insert(0, ".")
     import play
-    from play.callback import callback_manager, CallbackType
 
     ball = play.new_circle(x=0, y=0, radius=20)
     ball.start_physics(obeys_gravity=False)
@@ -95,34 +67,20 @@ def test_when_stopped_touching_callbacks_not_duplicated():
     async def on_stop_touch():
         pass
 
-    callbacks_before = list(
-        callback_manager.get_callback(CallbackType.WHEN_STOPPED_TOUCHING, id(ball))
-        or []
-    )
-    count_before = len(callbacks_before)
-
-    ball.start_physics(obeys_gravity=False)
-
-    callbacks_after = list(
-        callback_manager.get_callback(CallbackType.WHEN_STOPPED_TOUCHING, id(ball))
-        or []
-    )
-    count_after = len(callbacks_after)
-
-    assert (
-        count_before == count_after
-    ), f"when_stopped_touching callbacks changed from {count_before} to {count_after} after start_physics"
+    with pytest.raises(
+        RuntimeError, match="already has collision callbacks registered"
+    ):
+        ball.start_physics(obeys_gravity=False)
 
     play.stop_program()
 
 
-def test_when_stopped_touching_wall_callbacks_not_duplicated():
-    """Calling start_physics a second time should not duplicate when_stopped_touching_wall callbacks."""
+def test_start_physics_raises_when_stopped_touching_wall_registered():
+    """start_physics should raise RuntimeError if when_stopped_touching_wall callbacks exist."""
     import sys
 
     sys.path.insert(0, ".")
     import play
-    from play.callback import callback_manager, CallbackType
 
     ball = play.new_circle(x=0, y=0, radius=20)
     ball.start_physics(obeys_gravity=False)
@@ -131,128 +89,74 @@ def test_when_stopped_touching_wall_callbacks_not_duplicated():
     async def on_stop_wall():
         pass
 
-    callbacks_before = list(
-        callback_manager.get_callback(CallbackType.WHEN_STOPPED_TOUCHING_WALL, id(ball))
-        or []
-    )
-    count_before = len(callbacks_before)
-
-    ball.start_physics(obeys_gravity=False)
-
-    callbacks_after = list(
-        callback_manager.get_callback(CallbackType.WHEN_STOPPED_TOUCHING_WALL, id(ball))
-        or []
-    )
-    count_after = len(callbacks_after)
-
-    assert (
-        count_before == count_after
-    ), f"when_stopped_touching_wall callbacks changed from {count_before} to {count_after} after start_physics"
+    with pytest.raises(
+        RuntimeError, match="already has collision callbacks registered"
+    ):
+        ball.start_physics(obeys_gravity=False)
 
     play.stop_program()
 
 
-def test_multiple_start_physics_calls_preserve_callbacks():
-    """Calling start_physics 3 times should still have the same callback count as after the first."""
+def test_start_physics_ok_without_callbacks():
+    """start_physics should succeed when no callbacks are registered."""
     import sys
 
     sys.path.insert(0, ".")
     import play
-    from play.callback import callback_manager, CallbackType
 
     ball = play.new_circle(x=0, y=0, radius=20)
     ball.start_physics(obeys_gravity=False)
 
-    other = play.new_box(x=200, y=0, width=10, height=100)
-    other.start_physics(obeys_gravity=False, can_move=False)
+    # Calling again without callbacks should work fine
+    ball.start_physics(obeys_gravity=False)
 
-    @ball.when_touching(other)
-    async def on_touch():
-        pass
+    play.stop_program()
+
+
+def test_stop_physics_clears_callbacks_then_restarts():
+    """stop_physics should clear callbacks and successfully call start_physics."""
+    import sys
+
+    sys.path.insert(0, ".")
+    import play
+
+    ball = play.new_circle(x=0, y=0, radius=20)
+    ball.start_physics(obeys_gravity=False)
 
     @ball.when_touching_wall
     async def on_wall():
         pass
 
-    touching_before = len(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING, id(ball)) or []
-    )
-    wall_before = len(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING_WALL, id(ball)) or []
-    )
-
-    # Call start_physics two more times
-    ball.start_physics(obeys_gravity=False)
-    ball.start_physics(obeys_gravity=False)
-
-    touching_after = len(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING, id(ball)) or []
-    )
-    wall_after = len(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING_WALL, id(ball)) or []
-    )
-
-    assert (
-        touching_before == touching_after
-    ), f"when_touching callbacks changed from {touching_before} to {touching_after} after 3x start_physics"
-    assert (
-        wall_before == wall_after
-    ), f"when_touching_wall callbacks changed from {wall_before} to {wall_after} after 3x start_physics"
+    # stop_physics should work even with callbacks registered
+    ball.stop_physics()
 
     play.stop_program()
 
 
-def test_other_sprite_start_physics_preserves_dependent_callbacks():
-    """When sprite B calls start_physics, callbacks registered by sprite A
-    referencing B should be re-registered with B's new physics shape."""
+def test_start_physics_raises_when_dependent_sprite_has_callback():
+    """start_physics should raise RuntimeError if another sprite has a callback referencing this sprite."""
     import sys
 
     sys.path.insert(0, ".")
     import play
-    from play.callback import callback_manager, CallbackType
 
-    bal = play.new_circle(x=0, y=0, radius=20)
-    bal.start_physics(obeys_gravity=False)
+    ball = play.new_circle(x=0, y=0, radius=20)
+    ball.start_physics(obeys_gravity=False)
 
-    batje = play.new_box(x=200, y=0, width=10, height=100)
-    batje.start_physics(obeys_gravity=False, can_move=False)
+    wall = play.new_box(x=200, y=0, width=10, height=100)
+    wall.start_physics(obeys_gravity=False, can_move=False)
 
-    @bal.when_touching(batje)
+    @ball.when_touching(wall)
     async def on_touch():
         pass
 
-    @bal.when_stopped_touching(batje)
-    async def on_stop_touch():
-        pass
-
-    touching_before = len(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING, id(bal)) or []
-    )
-    stopped_before = len(
-        callback_manager.get_callback(CallbackType.WHEN_STOPPED_TOUCHING, id(bal)) or []
-    )
-
-    # Call start_physics on the OTHER sprite (batje)
-    batje.start_physics(obeys_gravity=False, can_move=False)
-
-    touching_after = len(
-        callback_manager.get_callback(CallbackType.WHEN_TOUCHING, id(bal)) or []
-    )
-    stopped_after = len(
-        callback_manager.get_callback(CallbackType.WHEN_STOPPED_TOUCHING, id(bal)) or []
-    )
-
-    assert touching_before == touching_after, (
-        f"when_touching callbacks changed from {touching_before} to {touching_after} "
-        f"after other sprite called start_physics"
-    )
-    assert stopped_before == stopped_after, (
-        f"when_stopped_touching callbacks changed from {stopped_before} to {stopped_after} "
-        f"after other sprite called start_physics"
-    )
+    # Calling start_physics on 'wall' should fail because 'ball' has a
+    # when_touching callback that references 'wall'
+    with pytest.raises(RuntimeError, match="callback referencing it"):
+        wall.start_physics(obeys_gravity=False, can_move=False)
 
     play.stop_program()
 
 
 if __name__ == "__main__":
-    test_when_touching_callbacks_not_duplicated()
+    test_start_physics_raises_when_touching_registered()


### PR DESCRIPTION
this is no longer allowed to help the user:

```python
import play

bal = play.new_box()

@bal.when_stopped_touching_wall
def hello():
    pass

bal.start_physics()

play.start_program()
```

a user now only calls start_physics at the top and knows which pymunk body type it is. 