### PR TITLE
feat: add hex code support to color system

### DIFF
--- a/play/utils/__init__.py
+++ b/play/utils/__init__.py
@@ -97,16 +97,39 @@ def color_name_to_rgb(
     name: str, transparency: int = 255
 ) -> tuple[int, int, int, int] | tuple | str:
     """
-    Turn an English color name into an RGB value.
+    Turn an English color name or hex code into an RGB value.
 
     lightBlue
     light-blue
     light blue
+    #FF0000
+    #f00
 
-    are all valid and will produce the rgb value for lightblue.
+    are all valid and will produce an RGB value.
     """
     if isinstance(name, tuple):
         return name
+
+    # Handle hex color codes (#RGB or #RRGGBB)
+    stripped = name.strip()
+    if stripped.startswith("#"):
+        hex_val = stripped[1:]
+        if len(hex_val) == 3:
+            # Expand shorthand: #F00 -> FF0000
+            hex_val = hex_val[0] * 2 + hex_val[1] * 2 + hex_val[2] * 2
+        if len(hex_val) == 6:
+            try:
+                r = int(hex_val[0:2], 16)
+                g = int(hex_val[2:4], 16)
+                b = int(hex_val[4:6], 16)
+                return (r, g, b, transparency)
+            except ValueError:
+                pass
+        raise ValueError(
+            f"You gave an invalid hex color code: '{name}'\n"
+            "Hex codes should be 3 or 6 hex digits after '#', like '#FF0000' or '#F00'.\n"
+        )
+
     try:
         color = pygame.color.THECOLORS[
             name.lower().strip().replace("-", "").replace(" ", "")

--- a/play/utils/__init__.py
+++ b/play/utils/__init__.py
@@ -132,7 +132,7 @@ def color_name_to_rgb(
 
     try:
         color = pygame.color.THECOLORS[
-            name.lower().strip().replace("-", "").replace(" ", "")
+            stripped.lower().replace("-", "").replace(" ", "")
         ]
         # Make the last item of the tuple the transparency value
         color = (color[0], color[1], color[2], transparency)

--- a/play/utils/__init__.py
+++ b/play/utils/__init__.py
@@ -125,13 +125,13 @@ def color_name_to_rgb(
     try:
         c = pygame.Color(color_str)
         return (c.r, c.g, c.b, transparency)
-    except ValueError:
+    except ValueError as exc:
         raise ValueError(
             f"""You gave a color name we didn't understand: '{name}'
 Try using a hex code like '#FF0000' or '#F00',
 or the RGB number form e.g. '(0, 255, 255)'.
 You can find the RGB form of a color on websites like this: https://www.rapidtables.com/web/color/RGB_Color.html\n"""
-        )
+        ) from exc
 
 
 def is_called_from_pygame():

--- a/play/utils/__init__.py
+++ b/play/utils/__init__.py
@@ -110,39 +110,28 @@ def color_name_to_rgb(
     if isinstance(name, tuple):
         return name
 
-    # Handle hex color codes (#RGB or #RRGGBB)
     stripped = name.strip()
-    if stripped.startswith("#"):
-        hex_val = stripped[1:]
-        if len(hex_val) == 3:
-            # Expand shorthand: #F00 -> FF0000
-            hex_val = hex_val[0] * 2 + hex_val[1] * 2 + hex_val[2] * 2
-        if len(hex_val) == 6:
-            try:
-                r = int(hex_val[0:2], 16)
-                g = int(hex_val[2:4], 16)
-                b = int(hex_val[4:6], 16)
-                return (r, g, b, transparency)
-            except ValueError:
-                pass
-        raise ValueError(
-            f"You gave an invalid hex color code: '{name}'\n"
-            "Hex codes should be 3 or 6 hex digits after '#', like '#FF0000' or '#F00'.\n"
-        )
+    # Expand shorthand hex: #F00 -> #FF0000
+    if stripped.startswith("#") and len(stripped) == 4:
+        stripped = "#" + stripped[1] * 2 + stripped[2] * 2 + stripped[3] * 2
+
+    # Normalize color names: "light blue", "light-blue", "lightBlue" -> "lightblue"
+    color_str = (
+        stripped
+        if stripped.startswith("#")
+        else stripped.lower().replace("-", "").replace(" ", "")
+    )
 
     try:
-        color = pygame.color.THECOLORS[
-            stripped.lower().replace("-", "").replace(" ", "")
-        ]
-        # Make the last item of the tuple the transparency value
-        color = (color[0], color[1], color[2], transparency)
-        return color
-    except KeyError as exception:
+        c = pygame.Color(color_str)
+        return (c.r, c.g, c.b, transparency)
+    except ValueError:
         raise ValueError(
             f"""You gave a color name we didn't understand: '{name}'
-Try using the RGB number form of the color e.g. '(0, 255, 255)'.
+Try using a hex code like '#FF0000' or '#F00',
+or the RGB number form e.g. '(0, 255, 255)'.
 You can find the RGB form of a color on websites like this: https://www.rapidtables.com/web/color/RGB_Color.html\n"""
-        ) from exception
+        )
 
 
 def is_called_from_pygame():

--- a/tests/utils/test_properties.py
+++ b/tests/utils/test_properties.py
@@ -86,12 +86,17 @@ def test_color_name_to_rgb_invalid_strings(invalid_name):
     """
     Test that invalid color strings raise ValueError.
     """
+    import re
+
     # Filter out strings that might actually be valid Pygame colors
     valid_pygame_colors = [c.lower() for c in pygame.color.THECOLORS.keys()]
     test_name = invalid_name.lower().strip().replace("-", "").replace(" ", "")
 
+    # Filter out valid hex color codes (#RGB or #RRGGBB) — these are now valid inputs
+    stripped = invalid_name.strip()
+    if re.fullmatch(r"#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}", stripped):
+        return
+
     if test_name not in valid_pygame_colors:
-        with pytest.raises(
-            ValueError, match="You gave a color name we didn't understand"
-        ):
+        with pytest.raises(ValueError, match="You gave"):
             color_name_to_rgb(invalid_name)

--- a/tests/utils/test_properties.py
+++ b/tests/utils/test_properties.py
@@ -2,7 +2,9 @@
 
 import pygame
 import pytest
-from hypothesis import given, strategies as st
+import re
+
+from hypothesis import assume, given, strategies as st
 
 from play.utils import clamp, color_name_to_rgb
 
@@ -86,16 +88,13 @@ def test_color_name_to_rgb_invalid_strings(invalid_name):
     """
     Test that invalid color strings raise ValueError.
     """
-    import re
-
     # Filter out strings that might actually be valid Pygame colors
     valid_pygame_colors = [c.lower() for c in pygame.color.THECOLORS.keys()]
     test_name = invalid_name.lower().strip().replace("-", "").replace(" ", "")
 
     # Filter out valid hex color codes (#RGB or #RRGGBB) — these are now valid inputs
     stripped = invalid_name.strip()
-    if re.fullmatch(r"#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}", stripped):
-        return
+    assume(not re.fullmatch(r"#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}", stripped))
 
     if test_name not in valid_pygame_colors:
         with pytest.raises(ValueError, match="You gave"):

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -241,6 +241,12 @@ def test_color_name_to_rgb_hex_invalid():
     with pytest.raises(ValueError, match="invalid hex color code"):
         color_name_to_rgb("#12345")  # 5 digits — invalid length
 
+    with pytest.raises(ValueError, match="invalid hex color code"):
+        color_name_to_rgb("#GGG")  # 3-digit shorthand with invalid hex chars
+
+    with pytest.raises(ValueError, match="invalid hex color code"):
+        color_name_to_rgb("#")  # just the hash, no digits
+
 
 def test_color_name_to_rgb_hex_whitespace():
     """Test that hex codes with surrounding whitespace are handled."""

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -166,3 +166,87 @@ def test_color_name_to_rgb_case_insensitive():
     red3 = color_name_to_rgb("Red")
 
     assert red1[:3] == red2[:3] == red3[:3]
+
+
+def test_color_name_to_rgb_hex_six_digit():
+    """Test color_name_to_rgb with 6-digit hex codes."""
+    from play.utils import color_name_to_rgb
+
+    red = color_name_to_rgb("#FF0000")
+    assert red[0] == 255
+    assert red[1] == 0
+    assert red[2] == 0
+    assert red[3] == 255  # default transparency
+
+    green = color_name_to_rgb("#00FF00")
+    assert green[0] == 0
+    assert green[1] == 255
+    assert green[2] == 0
+
+    blue = color_name_to_rgb("#0000FF")
+    assert blue[0] == 0
+    assert blue[1] == 0
+    assert blue[2] == 255
+
+
+def test_color_name_to_rgb_hex_three_digit():
+    """Test color_name_to_rgb with 3-digit shorthand hex codes."""
+    from play.utils import color_name_to_rgb
+
+    red = color_name_to_rgb("#F00")
+    assert red[0] == 255
+    assert red[1] == 0
+    assert red[2] == 0
+
+    white = color_name_to_rgb("#FFF")
+    assert white[0] == 255
+    assert white[1] == 255
+    assert white[2] == 255
+
+    black = color_name_to_rgb("#000")
+    assert black[0] == 0
+    assert black[1] == 0
+    assert black[2] == 0
+
+
+def test_color_name_to_rgb_hex_lowercase():
+    """Test that hex codes are case insensitive."""
+    from play.utils import color_name_to_rgb
+
+    upper = color_name_to_rgb("#FF8800")
+    lower = color_name_to_rgb("#ff8800")
+    mixed = color_name_to_rgb("#Ff8800")
+
+    assert upper[:3] == lower[:3] == mixed[:3]
+
+
+def test_color_name_to_rgb_hex_with_transparency():
+    """Test hex codes with custom transparency."""
+    from play.utils import color_name_to_rgb
+
+    red = color_name_to_rgb("#FF0000", transparency=128)
+    assert red[0] == 255
+    assert red[1] == 0
+    assert red[2] == 0
+    assert red[3] == 128
+
+
+def test_color_name_to_rgb_hex_invalid():
+    """Test that invalid hex codes raise ValueError."""
+    from play.utils import color_name_to_rgb
+
+    with pytest.raises(ValueError, match="invalid hex color code"):
+        color_name_to_rgb("#GGGGGG")
+
+    with pytest.raises(ValueError, match="invalid hex color code"):
+        color_name_to_rgb("#12345")  # 5 digits — invalid length
+
+
+def test_color_name_to_rgb_hex_whitespace():
+    """Test that hex codes with surrounding whitespace are handled."""
+    from play.utils import color_name_to_rgb
+
+    red = color_name_to_rgb("  #FF0000  ")
+    assert red[0] == 255
+    assert red[1] == 0
+    assert red[2] == 0

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -235,16 +235,16 @@ def test_color_name_to_rgb_hex_invalid():
     """Test that invalid hex codes raise ValueError."""
     from play.utils import color_name_to_rgb
 
-    with pytest.raises(ValueError, match="invalid hex color code"):
+    with pytest.raises(ValueError, match="color name we didn't understand"):
         color_name_to_rgb("#GGGGGG")
 
-    with pytest.raises(ValueError, match="invalid hex color code"):
+    with pytest.raises(ValueError, match="color name we didn't understand"):
         color_name_to_rgb("#12345")  # 5 digits — invalid length
 
-    with pytest.raises(ValueError, match="invalid hex color code"):
+    with pytest.raises(ValueError, match="color name we didn't understand"):
         color_name_to_rgb("#GGG")  # 3-digit shorthand with invalid hex chars
 
-    with pytest.raises(ValueError, match="invalid hex color code"):
+    with pytest.raises(ValueError, match="color name we didn't understand"):
         color_name_to_rgb("#")  # just the hash, no digits
 
 


### PR DESCRIPTION
Support #RRGGBB and #RGB hex color codes in color_name_to_rgb(). Add tests covering 6-digit, 3-digit shorthand, case-insensitivity, transparency, whitespace trimming, and invalid hex error handling.

Closes #158