### PR TITLE
fix: remove pygame.key.set_repeat to fix while_key_pressed delay (#160)

### DIFF
--- a/play/io/keypress.py
+++ b/play/io/keypress.py
@@ -6,9 +6,6 @@ from ..callback import callback_manager, CallbackType
 from ..utils.async_helpers import make_async
 from ..callback.callback_helpers import run_async_callback
 
-pygame.key.set_repeat(200, 16)
-
-
 class KeyboardState:  # pylint: disable=too-few-public-methods
     """Class to manage the state of the keyboard."""
 

--- a/play/io/keypress.py
+++ b/play/io/keypress.py
@@ -6,6 +6,7 @@ from ..callback import callback_manager, CallbackType
 from ..utils.async_helpers import make_async
 from ..callback.callback_helpers import run_async_callback
 
+
 class KeyboardState:  # pylint: disable=too-few-public-methods
     """Class to manage the state of the keyboard."""
 

--- a/tests/events/test_while_pressed_events.py
+++ b/tests/events/test_while_pressed_events.py
@@ -91,6 +91,56 @@ def test_while_key_pressed_invalid_key_type():
             pass
 
 
+def test_while_key_pressed_fires_every_frame_without_keydown_repeat():
+    """Test that while_key_pressed fires on every game frame while a key is held,
+    NOT just when KEYDOWN events occur.
+
+    Previously, pygame.key.set_repeat(200, 16) was used to drive while_key_pressed
+    via repeated KEYDOWN events. This caused a 200ms delay before the first repeat,
+    then 16ms intervals — so 'key press 1 to key press 2' took 200ms while
+    'key press 2 to key press 3' only took 16ms (issue #160).
+
+    The fix: while_key_pressed is driven by keyboard_state.pressed (frame-based),
+    not by KEYDOWN repeat events. This test verifies the callback fires on every
+    handle_keyboard() call while a key remains in keyboard_state.pressed.
+    """
+    import asyncio
+    import pygame
+    from play.io.keypress import keyboard_state
+    from play.core.keyboard_loop import handle_keyboard_events, handle_keyboard
+    from play.callback import callback_manager, CallbackType
+    from play.loop import get_loop
+    import play
+
+    loop = get_loop()
+    fired_count = [0]
+
+    @play.while_key_pressed("right")
+    def on_right_held(key=None):
+        fired_count[0] += 1
+
+    # Simulate initial KEYDOWN
+    down = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_RIGHT})
+    handle_keyboard_events(down)
+    assert "right" in keyboard_state.pressed
+
+    # Run handle_keyboard multiple times WITHOUT any new KEYDOWN events
+    # (simulating held key across multiple game frames)
+    for _ in range(5):
+        loop.run_until_complete(handle_keyboard())
+        loop.run_until_complete(asyncio.sleep(0))  # let fire_async_callback tasks run
+        keyboard_state.pressed_this_frame.clear()
+        keyboard_state.released.clear()
+
+    assert fired_count[0] == 5, (
+        f"while_key_pressed should fire every frame while key is held, "
+        f"got {fired_count[0]} fires in 5 frames"
+    )
+
+    # Clean up
+    keyboard_state.pressed.clear()
+
+
 def test_while_key_pressed_uses_pressed_not_pressed_this_frame():
     """Test that WHILE_KEY_PRESSED uses keyboard_state.pressed (held keys),
     whereas PRESSED_KEYS uses keyboard_state.pressed_this_frame (new keys only).

--- a/tests/events/test_while_pressed_events.py
+++ b/tests/events/test_while_pressed_events.py
@@ -123,6 +123,9 @@ def test_while_key_pressed_fires_every_frame_without_keydown_repeat():
     down = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_RIGHT})
     handle_keyboard_events(down)
     assert "right" in keyboard_state.pressed
+    assert (
+        fired_count[0] == 0
+    )  # handle_keyboard_events alone does not fire the callback
 
     # Run handle_keyboard multiple times WITHOUT any new KEYDOWN events
     # (simulating held key across multiple game frames)


### PR DESCRIPTION
pygame.key.set_repeat(200, 16) was a leftover from an older implementation of while_key_pressed that relied on repeated KEYDOWN events to drive callbacks. This caused the classic keyboard repeat delay: 200ms before the first repeat, then 16ms intervals — so the gap between callback invocations 1 and 2 was much larger than between 2 and 3 (issue #160).

The modern implementation drives while_key_pressed every game frame via keyboard_state.pressed, so set_repeat is no longer needed. Removing it ensures while_key_pressed fires uniformly on every frame while a key is held.

Also adds a regression test verifying that while_key_pressed fires on every handle_keyboard() call without requiring any KEYDOWN events to occur.