### PR TITLE
chore: add CLAUDE.md as Python library scope marker

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# play — Python-bibliotheek (geen docs-repo)
+
+De schrijfstijl en didactiek uit `../CLAUDE.md` gelden **niet** voor deze repo. Dit is een Python-package (`pyproject.toml`, `setup.py`, `tests/`), niet een Docusaurus-leersite.
+
+## Conventies
+
+- Volg de bestaande package layout (`play/`, `tests/`).
+- Pytest voor tests.
+- Geen Nederlandse leerlinginstructies, geen PRIMM, geen `<details>`-blokken.
+- Wijzigingen die de publieke API raken stralen uit naar `../play-docs/`: noem dat in de PR-beschrijving en update beide repos in dezelfde wijzigingsronde.


### PR DESCRIPTION
Makes explicit that the shared docs-writing rules from the parent working-directory CLAUDE.md (PRIMM, Nederlandse leerlinginstructies, <details>-blokken, …) do NOT apply here — this is a Python package, not a Docusaurus docs site.