### PR TITLE
fix: apply angle rotation and resolve system fonts in Text

### DIFF
--- a/play/objects/text.py
+++ b/play/objects/text.py
@@ -131,7 +131,9 @@ class Text(Sprite):
             if matched:
                 self._pygame_font = pygame.font.Font(matched, font_size)
             else:
-                play_logger.warning(f"Font '{font_name}' not found, using default font")
+                play_logger.warning(
+                    "Font '%s' not found, using default font", font_name
+                )
                 self._pygame_font = pygame.font.Font(
                     pygame.font.get_default_font(), font_size
                 )

--- a/play/objects/text.py
+++ b/play/objects/text.py
@@ -1,5 +1,6 @@
 """This module contains the Text class, which is a text string in the game."""
 
+import math as _math
 import os
 import pygame
 from .sprite import Sprite
@@ -47,19 +48,23 @@ class Text(Sprite):
         """Update the text object."""
         if self._should_recompute:
             pos = convert_pos(self.x, self.y)
-            self._image = self._pygame_font.render(
+            draw_image = self._pygame_font.render(
                 self._words, True, _color_name_to_rgb(self._color)
             )
             if self._size != 100:
-                new_w = max(round(self._image.get_width() * self._size / 100), 1)
-                new_h = max(round(self._image.get_height() * self._size / 100), 1)
-                self._image = pygame.transform.scale(self._image, (new_w, new_h))
-            self._image.set_alpha(round(self._transparency * 255 / 100))
-            self.rect = self._image.get_rect()
-            self.rect.topleft = (
-                pos[0] - self.rect.width // 2,
-                pos[1] - self.rect.height // 2,
-            )
+                new_w = max(round(draw_image.get_width() * self._size / 100), 1)
+                new_h = max(round(draw_image.get_height() * self._size / 100), 1)
+                draw_image = pygame.transform.scale(draw_image, (new_w, new_h))
+            if hasattr(self, "physics") and self.physics is not None:
+                angle_deg = _math.degrees(self.physics._pymunk_body.angle)
+            else:
+                angle_deg = self._angle
+            if angle_deg:
+                draw_image = pygame.transform.rotate(draw_image, angle_deg)
+            draw_image.set_alpha(round(self._transparency * 255 / 100))
+            self._image = draw_image
+            self.rect = draw_image.get_rect()
+            self.rect.center = pos
         super().update()
 
     def clone(self):
@@ -122,7 +127,11 @@ class Text(Sprite):
         elif os.path.isfile(font_name):
             self._pygame_font = pygame.font.Font(font_name, font_size)
         else:
-            play_logger.warning("File to font doesnt exist, Using default font")
-            self._pygame_font = pygame.font.Font(
-                pygame.font.get_default_font(), font_size
-            )
+            matched = pygame.font.match_font(font_name)
+            if matched:
+                self._pygame_font = pygame.font.Font(matched, font_size)
+            else:
+                play_logger.warning(f"Font '{font_name}' not found, using default font")
+                self._pygame_font = pygame.font.Font(
+                    pygame.font.get_default_font(), font_size
+                )

--- a/tests/objects/test_text.py
+++ b/tests/objects/test_text.py
@@ -377,3 +377,183 @@ def test_text_transparency():
 
     assert test_results["initial"] == 100
     assert test_results["updated"] == 50
+
+
+def test_text_angle_visually_applied():
+    """Verify rotation is actually applied to the rendered surface, not just stored."""
+    import play
+
+    results = {}
+    frames = [0]
+    text = play.new_text(words="Hello", angle=0)
+
+    @play.repeat_forever
+    def check():
+        if frames[0] > 0:
+            return
+        frames[0] += 1
+        results["size_0"] = text._image.get_size()
+        text.angle = 45
+        text._should_recompute = True
+        text.update()
+        results["size_45"] = text._image.get_size()
+        play.stop_program()
+
+    play.start_program()
+    assert results["size_0"] != results["size_45"]
+
+
+def test_text_font_setter():
+    """Verify the font setter reloads the pygame font object."""
+    import play
+
+    results = {}
+    frames = [0]
+    text = play.new_text()
+
+    @play.repeat_forever
+    def check():
+        if frames[0] > 0:
+            return
+        frames[0] += 1
+        first_font = text._pygame_font
+        text.font = "default"
+        results["font_name"] = text.font
+        results["font_reloaded"] = text._pygame_font is not first_font
+        play.stop_program()
+
+    play.start_program()
+    assert results["font_name"] == "default"
+    assert results["font_reloaded"]
+
+
+def test_text_font_invalid_name_falls_back(caplog):
+    """Verify unknown font names fall back to default and emit a warning."""
+    import logging
+    import play
+
+    frames = [0]
+
+    with caplog.at_level(logging.WARNING, logger="play"):
+        text = play.new_text(words="test", font="__nonexistent_xyz__")
+
+        @play.repeat_forever
+        def check():
+            if frames[0] > 0:
+                return
+            frames[0] += 1
+            play.stop_program()
+
+        play.start_program()
+
+    assert any("not found" in r.message for r in caplog.records)
+    assert text._image is not None
+
+
+def _find_non_default_font():
+    """Return the name of any available system font that differs from pygame's built-in default.
+
+    pygame's built-in is 'freesansbold.ttf'; skipping it ensures the chosen font
+    produces different glyph metrics.  Returns None if no system fonts are available.
+    """
+    import pygame
+
+    for name in pygame.font.get_fonts():
+        if name == "freesansbold":
+            continue
+        if pygame.font.match_font(name):
+            return name
+    return None
+
+
+def test_text_font_system_name_resolved():
+    """Verify system font names are resolved via match_font, not silently ignored."""
+    import play
+
+    results = {}
+    frames = [0]
+
+    system_font = _find_non_default_font()
+    if system_font is None:
+        pytest.skip("No non-default system font available")
+
+    text_default = play.new_text(words="Hello", font="default", font_size=40)
+    text_system = play.new_text(words="Hello", font=system_font, font_size=40)
+
+    @play.repeat_forever
+    def check():
+        if frames[0] > 0:
+            return
+        frames[0] += 1
+        results["default_w"] = text_default._image.get_width()
+        results["system_w"] = text_system._image.get_width()
+        play.stop_program()
+
+    play.start_program()
+    assert (
+        results["default_w"] != results["system_w"]
+    ), "System font should produce different image width than default font"
+
+
+def test_text_font_file_path():
+    """Verify that an absolute file path triggers the os.path.isfile branch in _load_font."""
+    import pygame
+    import play
+
+    results = {}
+    frames = [0]
+
+    system_font = _find_non_default_font()
+    if system_font is None:
+        pytest.skip("No non-default system font file available")
+    font_path = pygame.font.match_font(system_font)
+
+    text = play.new_text(words="Hello", font=font_path, font_size=40)
+    text_default = play.new_text(words="Hello", font="default", font_size=40)
+
+    @play.repeat_forever
+    def check():
+        if frames[0] > 0:
+            return
+        frames[0] += 1
+        results["font"] = text.font
+        results["width"] = text._image.get_width()
+        results["default_width"] = text_default._image.get_width()
+        play.stop_program()
+
+    play.start_program()
+    assert results["font"] == font_path
+    assert (
+        results["width"] != results["default_width"]
+    ), "Font loaded from file path should produce different glyph metrics than default"
+
+
+def test_text_font_setter_changes_rendering():
+    """Verify that changing the font property produces different rendered glyph metrics."""
+    import play
+
+    results = {}
+    frames = [0]
+
+    system_font = _find_non_default_font()
+    if system_font is None:
+        pytest.skip("No non-default system font available")
+
+    text = play.new_text(words="Hello", font="default", font_size=40)
+
+    @play.repeat_forever
+    def check():
+        if frames[0] > 0:
+            return
+        frames[0] += 1
+        results["default_w"] = text._image.get_width()
+        text.font = system_font
+        text._should_recompute = True
+        text.update()
+        results["system_w"] = text._image.get_width()
+        play.stop_program()
+
+    play.start_program()
+    assert (
+        results["default_w"] != results["system_w"]
+    ), "Changing font should produce different image width"

--- a/tests/objects/test_text.py
+++ b/tests/objects/test_text.py
@@ -404,7 +404,8 @@ def test_text_angle_visually_applied():
 
 
 def test_text_font_setter():
-    """Verify the font setter reloads the pygame font object."""
+    """Verify the font setter reloads _pygame_font with the correct metrics."""
+    import pygame
     import play
 
     results = {}
@@ -416,15 +417,19 @@ def test_text_font_setter():
         if frames[0] > 0:
             return
         frames[0] += 1
-        first_font = text._pygame_font
+        # Corrupt _pygame_font with a wrong size so a no-op setter would be detectable.
+        text._pygame_font = pygame.font.Font(pygame.font.get_default_font(), 999)
         text.font = "default"
         results["font_name"] = text.font
-        results["font_reloaded"] = text._pygame_font is not first_font
+        expected = pygame.font.Font(pygame.font.get_default_font(), text._font_size)
+        results["metrics_match"] = text._pygame_font.size("Hello") == expected.size(
+            "Hello"
+        )
         play.stop_program()
 
     play.start_program()
     assert results["font_name"] == "default"
-    assert results["font_reloaded"]
+    assert results["metrics_match"]
 
 
 def test_text_font_invalid_name_falls_back(caplog):
@@ -451,18 +456,27 @@ def test_text_font_invalid_name_falls_back(caplog):
 
 
 def _find_non_default_font():
-    """Return the name of any available system font that differs from pygame's built-in default.
-
-    pygame's built-in is 'freesansbold.ttf'; skipping it ensures the chosen font
-    produces different glyph metrics.  Returns None if no system fonts are available.
+    """Return the name of any available system font whose glyph metrics differ from
+    pygame's built-in default (freesansbold.ttf) at size 40.
+    Returns None if no such font is available.
     """
     import pygame
+
+    pygame.font.init()
+    probe = "AaBbCcDdEeFf"
+    default_w = pygame.font.Font(pygame.font.get_default_font(), 40).size(probe)[0]
 
     for name in pygame.font.get_fonts():
         if name == "freesansbold":
             continue
-        if pygame.font.match_font(name):
-            return name
+        path = pygame.font.match_font(name)
+        if not path:
+            continue
+        try:
+            if pygame.font.Font(path, 40).size(probe)[0] != default_w:
+                return name
+        except Exception:
+            continue
     return None
 
 


### PR DESCRIPTION
- Text.update() now calls pygame.transform.rotate() so the angle parameter visually affects the rendered surface; uses a hasattr guard for the pre-super().__init__() call in Text.__init__
- _load_font() now calls pygame.font.match_font() for system font names before falling back to the default font; improves warning message
- Add six tests that assert on rendered surface output rather than just stored property values, covering all three _load_font() branches