### PR TITLE
refactor: use correct data structures throughout (set, frozenset, uni…

### DIFF
--- a/play/callback/__init__.py
+++ b/play/callback/__init__.py
@@ -63,9 +63,9 @@ class CallbackManager:
 
     def remove_callbacks(self, callback_type, callback_discriminator=None) -> None:
         """
-        Remove all callbacks of a certain type.
+        Clear the callback bucket for a specific (callback_type, discriminator) pair.
         :param callback_type: The type of callback.
-        :param callback_discriminator: The discriminator for the callback.
+        :param callback_discriminator: The discriminator for the bucket to clear (None = unkeyed callbacks).
         :return: None
         """
         if callback_type not in self.callbacks:

--- a/play/callback/__init__.py
+++ b/play/callback/__init__.py
@@ -72,7 +72,8 @@ class CallbackManager:
             return
         # Clears only the bucket for callback_discriminator (None = unkeyed callbacks).
         # Does NOT wipe other discriminator buckets for this type.
-        self.callbacks[callback_type][callback_discriminator] = []
+        if callback_discriminator in self.callbacks[callback_type]:
+            self.callbacks[callback_type][callback_discriminator] = []
 
     def get_callbacks(self, callback_type) -> dict:
         """

--- a/play/callback/__init__.py
+++ b/play/callback/__init__.py
@@ -54,17 +54,10 @@ class CallbackManager:
             callback[0].type = callback_type
 
         if callback_type not in self.callbacks:
-            if callback_discriminator is None:
-                self.callbacks[callback_type] = []
-            else:
-                self.callbacks[callback_type] = {}
-
-        if callback_discriminator is None:
-            self.callbacks[callback_type].append(callback)
-        else:
-            if callback_discriminator not in self.callbacks[callback_type]:
-                self.callbacks[callback_type][callback_discriminator] = []
-            self.callbacks[callback_type][callback_discriminator].append(callback)
+            self.callbacks[callback_type] = {}
+        self.callbacks[callback_type].setdefault(callback_discriminator, []).append(
+            callback
+        )
 
         self.on_first_callback()
 
@@ -77,14 +70,9 @@ class CallbackManager:
         """
         if callback_type not in self.callbacks:
             return
-        if callback_discriminator is None:
-            existing = self.callbacks[callback_type]
-            self.callbacks[callback_type] = [] if isinstance(existing, list) else {}
-        elif (
-            isinstance(self.callbacks[callback_type], dict)
-            and callback_discriminator in self.callbacks[callback_type]
-        ):
-            self.callbacks[callback_type][callback_discriminator] = []
+        # Clears only the bucket for callback_discriminator (None = unkeyed callbacks).
+        # Does NOT wipe other discriminator buckets for this type.
+        self.callbacks[callback_type][callback_discriminator] = []
 
     def get_callbacks(self, callback_type) -> dict:
         """
@@ -105,15 +93,10 @@ class CallbackManager:
             callbacks = []
             for ctype in callback_type:
                 if ctype in self.callbacks:
-                    if callback_discriminator is None:
-                        callbacks.extend(self.callbacks[ctype])
-                    else:
-                        callbacks.extend(
-                            self.callbacks[ctype].get(callback_discriminator, [])
-                        )
+                    callbacks.extend(
+                        self.callbacks[ctype].get(callback_discriminator, [])
+                    )
             return callbacks
-        if callback_discriminator is None:
-            return self.callbacks.get(callback_type, None)
         return self.callbacks.get(callback_type, {}).get(callback_discriminator, None)
 
     def run_callbacks(
@@ -141,17 +124,9 @@ class CallbackManager:
                 return False
             return True
 
-        if callback_discriminator is not None:
-            if callback_discriminator not in self.callbacks[callback_type]:
-                return
-
-            for callback in self.callbacks[callback_type][callback_discriminator]:
-                if is_valid_callback(callback):
-                    run_callback(callback, [], [], *args, **kwargs)
-        else:
-            for callback in self.callbacks[callback_type]:
-                if is_valid_callback(callback):
-                    run_callback(callback, [], [], *args, **kwargs)
+        for callback in self.callbacks[callback_type].get(callback_discriminator, []):
+            if is_valid_callback(callback):
+                run_callback(callback, [], [], *args, **kwargs)
 
     async def run_callbacks_inline(self, callback_type):
         """Run all callbacks of a type inline (awaited directly), not as separate tasks.
@@ -160,15 +135,14 @@ class CallbackManager:
         scheduling order differs) callbacks always run synchronously within the caller's
         frame, seeing fully up-to-date state.
 
-        NOTE: Only safe for callback types whose storage is a list (e.g. REPEAT_FOREVER).
-        Dict-based callback types (e.g. PRESSED_KEYS) store callbacks under discriminator
-        keys, so iterating self.callbacks[callback_type] would yield keys, not callables.
-        Use run_callbacks_with_filter() for those types instead.
+        NOTE: Only fires callbacks registered without a discriminator (e.g. REPEAT_FOREVER).
+        Callback types that use discriminator keys (e.g. PRESSED_KEYS) should use
+        run_callbacks_with_filter() instead.
         """
         if callback_type not in self.callbacks:
             return
 
-        for callback in list(self.callbacks[callback_type]):
+        for callback in list(self.callbacks[callback_type].get(None, [])):
             if callable(callback) and not (
                 hasattr(callback, "is_running") and callback.is_running
             ):

--- a/play/core/keyboard_loop.py
+++ b/play/core/keyboard_loop.py
@@ -16,13 +16,13 @@ def handle_keyboard_events(event):
         if event.key not in KEYS_TO_SKIP:
             name = _pygame_key_to_name(event)
             if name not in keyboard_state.pressed:
-                keyboard_state.pressed.append(name)
-                keyboard_state.pressed_this_frame.append(name)
+                keyboard_state.pressed.add(name)
+                keyboard_state.pressed_this_frame.add(name)
     if event.type == pygame.KEYUP:
         name = _pygame_key_to_name(event)
         if not (event.key in KEYS_TO_SKIP) and name in keyboard_state.pressed:
-            keyboard_state.released.append(name)
-            keyboard_state.pressed.remove(name)
+            keyboard_state.released.add(name)
+            keyboard_state.pressed.discard(name)
 
 
 async def handle_keyboard():

--- a/play/io/keypress.py
+++ b/play/io/keypress.py
@@ -12,9 +12,9 @@ class KeyboardState:  # pylint: disable=too-few-public-methods
 
     def __init__(self):
         """Initialize the keyboard state."""
-        self.pressed = []  # keys currently held down
-        self.released = []  # keys released this frame
-        self.pressed_this_frame = []  # keys newly pressed via KEYDOWN this frame
+        self.pressed = set()  # keys currently held down
+        self.released = set()  # keys released this frame
+        self.pressed_this_frame = set()  # keys newly pressed via KEYDOWN this frame
 
     def clear(self):
         """Clear per-frame state (newly pressed and released this frame).

--- a/play/objects/components.py
+++ b/play/objects/components.py
@@ -14,7 +14,7 @@ class EventComponent:
         self._sprite = sprite
         self._touching_callback = {}
         self._stopped_callback = {}
-        self._dependent_sprites = []
+        self._dependent_sprites = set()
         self._is_clicked = False
 
     @property
@@ -124,7 +124,7 @@ class EventComponent:
                 await run_async_callback(async_callback, [], [])
 
             for target in sprites_to_check:
-                target.events._dependent_sprites.append(self._sprite)
+                target.events._dependent_sprites.add(self._sprite)
                 callback_manager.add_callback(
                     CallbackType.WHEN_TOUCHING, (wrapper, target), id(self._sprite)
                 )
@@ -154,7 +154,7 @@ class EventComponent:
                 await run_async_callback(async_callback, [], [])
 
             for target in sprites_to_check:
-                target.events._dependent_sprites.append(self._sprite)
+                target.events._dependent_sprites.add(self._sprite)
                 callback_manager.add_callback(
                     CallbackType.WHEN_STOPPED_TOUCHING,
                     (wrapper, target),

--- a/play/objects/sprite.py
+++ b/play/objects/sprite.py
@@ -25,11 +25,13 @@ def point_touching_sprite(point, sprite):
     return point_info.distance <= 0
 
 
-_should_ignore_update = [
-    "_should_recompute",
-    "rect",
-    "_image",
-]
+_should_ignore_update = frozenset(
+    {
+        "_should_recompute",
+        "rect",
+        "_image",
+    }
+)
 
 
 class Sprite(pygame.sprite.Sprite):  # pylint: disable=too-many-public-methods
@@ -365,6 +367,11 @@ You might want to look in your code where you're setting transparency and make s
         """Remove the sprite from the screen."""
         if not self.alive():
             return
+        saved = self._save_and_clear_callbacks()
+        for cb_type in [CallbackType.WHEN_TOUCHING, CallbackType.WHEN_STOPPED_TOUCHING]:
+            for _, target in saved.get(cb_type, []):
+                if hasattr(target, "events"):
+                    target.events._dependent_sprites.discard(self)
         self.physics._remove()
         globals_list.sprites_group.remove(self)
 

--- a/play/objects/sprite.py
+++ b/play/objects/sprite.py
@@ -368,10 +368,14 @@ You might want to look in your code where you're setting transparency and make s
         if not self.alive():
             return
         saved = self._save_and_clear_callbacks()
+        # Wall callback types don't register in _dependent_sprites, so only
+        # WHEN_TOUCHING / WHEN_STOPPED_TOUCHING need cleanup here.
         for cb_type in [CallbackType.WHEN_TOUCHING, CallbackType.WHEN_STOPPED_TOUCHING]:
-            for _, target in saved.get(cb_type, []):
-                if hasattr(target, "events"):
-                    target.events._dependent_sprites.discard(self)
+            for item in saved.get(cb_type, []):
+                if isinstance(item, tuple) and len(item) == 2:
+                    _, target = item
+                    if hasattr(target, "events"):
+                        target.events._dependent_sprites.discard(self)
         self.physics._remove()
         globals_list.sprites_group.remove(self)
 

--- a/tests/core/test_keyboard_loop_coverage.py
+++ b/tests/core/test_keyboard_loop_coverage.py
@@ -24,7 +24,7 @@ def test_handle_keydown_no_duplicates():
     event = pygame.event.Event(pygame.KEYDOWN, {"key": pygame.K_b})
     handle_keyboard_events(event)
     handle_keyboard_events(event)
-    assert keyboard_state.pressed.count("b") == 1
+    assert "b" in keyboard_state.pressed
 
 
 def test_handle_keyup_removes_from_pressed():

--- a/tests/events/test_api_events.py
+++ b/tests/events/test_api_events.py
@@ -32,24 +32,31 @@ def test_when_program_starts():
         pass
 
     assert CallbackType.WHEN_PROGRAM_START in callback_manager.callbacks
-    assert len(callback_manager.callbacks[CallbackType.WHEN_PROGRAM_START]) == 1
+    assert (
+        len(callback_manager.callbacks[CallbackType.WHEN_PROGRAM_START].get(None, []))
+        == 1
+    )
 
 
 def test_repeat_forever():
     """Test that repeat_forever registers a callback and sets is_running properly."""
     # The clean_play_state fixture pre-registers a safety-stop callback, so count
     # the existing entries before registering ours.
-    before = len(callback_manager.callbacks.get(CallbackType.REPEAT_FOREVER, []))
+    before = len(
+        callback_manager.callbacks.get(CallbackType.REPEAT_FOREVER, {}).get(None, [])
+    )
 
     @repeat_forever
     def dummy_func():
         pass
 
     assert CallbackType.REPEAT_FOREVER in callback_manager.callbacks
-    assert len(callback_manager.callbacks[CallbackType.REPEAT_FOREVER]) == before + 1
+    assert (
+        len(callback_manager.callbacks[CallbackType.REPEAT_FOREVER][None]) == before + 1
+    )
 
     # Check that our wrapper has the is_running attribute initialized to False
-    wrapper = callback_manager.callbacks[CallbackType.REPEAT_FOREVER][-1]
+    wrapper = callback_manager.callbacks[CallbackType.REPEAT_FOREVER][None][-1]
     assert hasattr(wrapper, "is_running")
     assert wrapper.is_running is False
 

--- a/tests/events/test_keyboard_events.py
+++ b/tests/events/test_keyboard_events.py
@@ -174,8 +174,8 @@ def test_keyboard_state_initial():
     from play.io.keypress import keyboard_state
 
     # Initially empty
-    assert isinstance(keyboard_state.pressed, list)
-    assert isinstance(keyboard_state.released, list)
+    assert isinstance(keyboard_state.pressed, set)
+    assert isinstance(keyboard_state.released, set)
 
 
 def test_keyboard_state_clear():
@@ -183,8 +183,8 @@ def test_keyboard_state_clear():
     from play.io.keypress import keyboard_state
 
     # Add some released keys
-    keyboard_state.released.append("a")
-    keyboard_state.released.append("b")
+    keyboard_state.released.add("a")
+    keyboard_state.released.add("b")
 
     # Clear
     keyboard_state.clear()

--- a/tests/objects/test_components.py
+++ b/tests/objects/test_components.py
@@ -109,6 +109,29 @@ def test_event_component_touching_decorators():
     assert sprite1 in sprite2.events._dependent_sprites
 
 
+def test_remove_cleans_up_dependent_sprites():
+    """sprite.remove() must remove self from every target's _dependent_sprites
+    and clear its callbacks from callback_manager."""
+    from play.callback import callback_manager, CallbackType
+
+    sprite1 = play.new_box(color="red", x=0, y=0, width=10, height=10)
+    sprite2 = play.new_box(color="blue", x=100, y=100, width=10, height=10)
+    sprite1.start_physics()
+    sprite2.start_physics()
+
+    async def mock_touching():
+        pass
+
+    sprite1.when_touching(sprite2)(mock_touching)
+    assert sprite1 in sprite2.events._dependent_sprites
+
+    sprite1_id = id(sprite1)
+    sprite1.remove()
+
+    assert sprite1 not in sprite2.events._dependent_sprites
+    assert not callback_manager.get_callback(CallbackType.WHEN_TOUCHING, sprite1_id)
+
+
 def test_event_component_wall_decorators():
     sprite = play.new_circle(color="red", x=0, y=0, radius=10)
     sprite.start_physics()

--- a/tests/test_issue_122_fixes.py
+++ b/tests/test_issue_122_fixes.py
@@ -72,8 +72,8 @@ def test_keyboard_state_instance_isolation():
     kb2 = KeyboardState()
 
     # Modify one instance
-    kb1.pressed.append("a")
-    kb1.released.append("b")
+    kb1.pressed.add("a")
+    kb1.released.add("b")
 
     # Verify the other instance is not affected
     assert "a" not in kb2.pressed


### PR DESCRIPTION
…form dict)

- CallbackManager.callbacks: unify storage to always dict[discriminator→list], eliminating the heterogeneous list-vs-dict branching in add/remove/get/run
- KeyboardState.pressed/released/pressed_this_frame: list→set for O(1) membership tests and removal (was O(n) with list.remove/in)
- _should_ignore_update: list→frozenset (immutable constant, O(1) lookup)
- EventComponent._dependent_sprites: list→set to prevent duplicate entries and enable O(1) discard; sprite.remove() now cleans up stale entries