### PR TITLE
chore: bump version to 3.3.3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(HERE / "requirements.txt", "r", encoding="utf-8") as f:
 # This call to setup() does all the work
 setup(
     name="coderius-play",
-    version="3.3.2",
+    version="3.3.3",
     description="The easiest way to make games and media projects in Python.",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
3.3.2 was already published to PyPI; bumping to unblock the release pipeline.